### PR TITLE
Permissions-logging

### DIFF
--- a/src/core/config_manager.py
+++ b/src/core/config_manager.py
@@ -10,6 +10,7 @@ import os
 import tempfile
 from typing import Dict, Any 
 from src.core.database import get_connection, init_db
+from src.core.utils import log_event
 import os
 
 # Default config if no file exists or file is invalid
@@ -141,3 +142,27 @@ def load_config():
             return json.load(f)
 
     return {}
+
+def request_external_service_permission(service_name: str = "External Service") -> bool:
+    """
+    Ask the user for permission to use an external service (e.g., LLM/API)
+    and log the decision to consent_log.json.
+    """
+    print(f"\nPermission Request: {service_name}")
+    print("This service may send limited data externally for processing.")
+    print("Only the data you select will be shared.")
+    print("You can deny to keep all processing local.\n")
+
+    response = input(f"Do you allow {service_name}? (y/n): ").strip().lower()
+    allowed = response == "y"
+
+    # Save decision in config
+    cfg = read_cfg()
+    cfg["external_allowed"] = allowed
+    write_cfg(cfg)
+
+    # Log it for auditing
+    log_event(service_name, "granted" if allowed else "denied")
+
+    print(f"Access {'granted' if allowed else 'denied'} for {service_name}.")
+    return allowed

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -1,0 +1,24 @@
+import json
+from datetime import datetime
+from pathlib import Path
+
+LOG_FILE = Path(__file__).resolve().parent / "../data/consent_log.json"
+
+def log_event(service_name: str, status: str):
+    """Log user consent decisions with timestamps."""
+    log_entry = {
+        "service": service_name,
+        "status": status,
+        "timestamp": datetime.now().isoformat()
+    }
+
+    logs = []
+    if LOG_FILE.exists():
+        try:
+            logs = json.loads(LOG_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            logs = []
+
+    logs.append(log_entry)
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    LOG_FILE.write_text(json.dumps(logs, indent=2))

--- a/src/data/consent_log.json
+++ b/src/data/consent_log.json
@@ -1,0 +1,7 @@
+[
+  {
+    "service": "API",
+    "status": "granted",
+    "timestamp": "2025-11-02T04:59:46.244664"
+  }
+]

--- a/src/main.py
+++ b/src/main.py
@@ -49,6 +49,11 @@ def status() -> None:
     """Print current consent and external-usage settings."""
     print(config_manager.read_cfg())
 
+@app.command()
+def external_permission(service: str = "API"):
+    """Ask for and log permission to use an external service."""
+    config_manager.request_external_service_permission(service)
+
 
 if __name__ == "__main__":
     print("Running in virtual env:", check_virtual_env())
@@ -69,3 +74,6 @@ if __name__ == "__main__":
         print(f"Config save/load skipped or failed: {e}")
 
     app()
+
+
+

--- a/tests/test_permissions_logging.py
+++ b/tests/test_permissions_logging.py
@@ -1,0 +1,65 @@
+import json
+from pathlib import Path
+import builtins
+import pytest
+from src.core import config_manager
+from src.core.utils import log_event, LOG_FILE
+
+@pytest.fixture(autouse=True)
+def clean_log_file(tmp_path, monkeypatch):
+    """Redirect the consent log file to a temporary location for isolation."""
+    test_log = tmp_path / "consent_log.json"
+    monkeypatch.setattr("src.core.utils.LOG_FILE", test_log)
+    yield test_log
+
+@pytest.fixture(autouse=True)
+def clean_config(tmp_path, monkeypatch):
+    """Redirect config.json to a temp file for isolation."""
+    test_cfg = tmp_path / "config.json"
+    monkeypatch.setattr("src.core.config_manager._get_cfg_path", lambda: test_cfg)
+    yield test_cfg
+
+
+def test_log_event_creates_file(clean_log_file):
+    """log_event() should create a file and write valid JSON."""
+    log_event("API", "granted")
+
+    assert clean_log_file.exists()
+    data = json.loads(clean_log_file.read_text())
+    assert len(data) == 1
+    assert data[0]["service"] == "API"
+    assert data[0]["status"] == "granted"
+    assert "timestamp" in data[0]
+
+
+def test_request_external_permission_granted(monkeypatch, clean_config, clean_log_file):
+    """Simulate user typing 'y' for permission (granted)."""
+    monkeypatch.setattr(builtins, "input", lambda _: "y")
+
+    result = config_manager.request_external_service_permission("Test_Service")
+    assert result is True
+
+    # Check config was updated
+    cfg = config_manager.read_cfg()
+    assert cfg["external_allowed"] is True
+
+    # Check log entry
+    logs = json.loads(clean_log_file.read_text())
+    assert logs[-1]["status"] == "granted"
+    assert logs[-1]["service"] == "Test_Service"
+
+
+def test_request_external_permission_denied(monkeypatch, clean_config, clean_log_file):
+    """Simulate user typing 'n' for permission (denied)."""
+    monkeypatch.setattr(builtins, "input", lambda _: "n")
+
+    result = config_manager.request_external_service_permission("Test_Service")
+    assert result is False
+
+    # Check config updated
+    cfg = config_manager.read_cfg()
+    assert cfg["external_allowed"] is False
+
+    # Check log entry
+    logs = json.loads(clean_log_file.read_text())
+    assert logs[-1]["status"] == "denied"


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Implemented the A3 – Permissions & Privacy Specialist functionality for the Config & Consent Manager.
This PR introduces an interactive permission prompt for using external services (e.g., LLM/API) and adds detailed consent logging for auditing and transparency.
A new helper module (utils.py) was added to handle log creation, and config_manager.py was updated with the function request_external_service_permission().
The CLI command external-permission was also integrated to test this feature easily.

**Closes:** # 59

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- Manual testing:

Run these commands: 
`python -m src.main external-permission --service "API"`
`cat src/data/consent_log.json`

Expected output

<img width="885" height="370" alt="Screenshot 2025-11-02 at 17 03 58" src="https://github.com/user-attachments/assets/2a55786c-a784-42ef-a6eb-8d9c32c0c2c9" />

Automated testing (Docker):

- Added: `tests/test_permissions_logging.py`

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile