### PR TITLE
Portfolio edit api

### DIFF
--- a/backend/src/api/routes/portfolio.py
+++ b/backend/src/api/routes/portfolio.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import Session
 
 from src.models.database import get_db
 from src.models.orm.user import User
-from src.models.schemas.portfolio import PortfolioResponse
+from src.models.schemas.portfolio import PortfolioResponse, PortfolioUpdate
+from src.api.exceptions import PortfolioNotFoundError
 from src.services.portfolio_service import PortfolioService
 from src.api.dependencies import get_current_user
 
@@ -39,4 +40,34 @@ async def generate_portfolio(
             status_code=500,
             detail=f"Portfolio generation failed: {str(e)}",
         )
+    return result
+
+
+@router.put("/{portfolio_id}/edit", response_model=PortfolioResponse)
+async def edit_portfolio(
+    portfolio_id: int,
+    data: PortfolioUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Edit an existing portfolio.
+
+    - Requires authentication (Bearer token)
+    - Only the portfolio owner can edit it
+    - Supports partial updates (only provided fields are changed)
+    - Returns 200 with the updated portfolio
+    """
+    service = PortfolioService(db)
+    result = service.update_portfolio(portfolio_id, data, current_user)
+
+    if result is None:
+        raise PortfolioNotFoundError(current_user.id)
+
+    if result == "forbidden":
+        raise HTTPException(
+            status_code=403,
+            detail="Not authorized to edit this portfolio",
+        )
+
     return result

--- a/backend/src/models/schemas/portfolio.py
+++ b/backend/src/models/schemas/portfolio.py
@@ -6,6 +6,14 @@ from typing import Dict, List, Optional, Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class PortfolioUpdate(BaseModel):
+    """Schema for updating a portfolio."""
+
+    title: Optional[str] = Field(None, max_length=255)
+    summary: Optional[str] = None
+    content: Optional[Dict[str, Any]] = None
+
+
 class PortfolioResponse(BaseModel):
     """Schema for portfolio response."""
 

--- a/backend/src/services/portfolio_service.py
+++ b/backend/src/services/portfolio_service.py
@@ -1,14 +1,14 @@
 """Portfolio service for portfolio operations."""
 
 import logging
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional, Union
 
 from sqlalchemy.orm import Session
 
 from src.config.settings import settings
 from src.models.orm.portfolio import Portfolio
 from src.models.orm.user import User
-from src.models.schemas.portfolio import PortfolioResponse
+from src.models.schemas.portfolio import PortfolioResponse, PortfolioUpdate
 from src.repositories.portfolio_repository import PortfolioRepository
 from src.repositories.project_repository import ProjectRepository
 from src.repositories.skill_repository import SkillRepository
@@ -129,6 +129,51 @@ class PortfolioService:
             portfolio = self.portfolio_repo.create(portfolio)
 
         logger.info(f"Generated portfolio {portfolio.id} for user {user_id}")
+
+        return PortfolioResponse(
+            id=portfolio.id,
+            user_id=portfolio.user_id,
+            title=portfolio.title,
+            summary=portfolio.summary,
+            content=portfolio.content,
+            created_at=portfolio.created_at,
+            updated_at=portfolio.updated_at,
+        )
+
+    def update_portfolio(
+        self,
+        portfolio_id: int,
+        data: PortfolioUpdate,
+        user: User,
+    ) -> Optional[Union[PortfolioResponse, str]]:
+        """
+        Update a portfolio by ID.
+
+        Args:
+            portfolio_id: The portfolio ID to update
+            data: PortfolioUpdate with fields to change (None fields are skipped)
+            user: The authenticated User ORM object
+
+        Returns:
+            PortfolioResponse on success, None if not found, "forbidden" if not owned
+        """
+        portfolio = self.portfolio_repo.get(portfolio_id)
+        if portfolio is None:
+            return None
+
+        if portfolio.user_id != user.id:
+            return "forbidden"
+
+        if data.title is not None:
+            portfolio.title = data.title
+        if data.summary is not None:
+            portfolio.summary = data.summary
+        if data.content is not None:
+            portfolio.content = data.content
+
+        portfolio = self.portfolio_repo.update(portfolio)
+
+        logger.info(f"Updated portfolio {portfolio.id} for user {user.id}")
 
         return PortfolioResponse(
             id=portfolio.id,

--- a/backend/tests/test_portfolio.py
+++ b/backend/tests/test_portfolio.py
@@ -1,4 +1,4 @@
-"""Tests for the Portfolio POST /generate endpoint, service, and generator."""
+"""Tests for the Portfolio endpoints, service, and generator."""
 
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from src.api.main import app
 from src.services.portfolio_service import PortfolioService
+from src.models.schemas.portfolio import PortfolioUpdate
 from src.core.generators.portfolio import (
     generate_portfolio,
     _generate_template_based,
@@ -371,3 +372,185 @@ def test_generate_portfolio_endpoint_server_error(mock_service_class):
 
     assert response.status_code == 500
     assert "failed" in response.json()["detail"].lower()
+
+
+# --- Edit service layer tests ---
+
+
+def _make_edit_service(portfolio=None):
+    """Helper to create a PortfolioService with mocked repos for edit tests."""
+    now = datetime.now(timezone.utc)
+
+    def fake_update(obj):
+        obj.updated_at = now
+        return obj
+
+    service = PortfolioService(db=None)
+    service.portfolio_repo = SimpleNamespace(
+        get=lambda pid: portfolio,
+        update=fake_update,
+    )
+    return service
+
+
+def test_edit_portfolio_updates_title_and_summary():
+    """Service updates title and summary when both provided."""
+    now = datetime.now(timezone.utc)
+    portfolio = SimpleNamespace(
+        id=1, user_id=10, title="Old Title", summary="Old summary.",
+        content={"projects": []}, created_at=now, updated_at=now,
+    )
+
+    service = _make_edit_service(portfolio=portfolio)
+    user = SimpleNamespace(id=10, email="test@example.com")
+
+    result = service.update_portfolio(
+        portfolio_id=1,
+        data=PortfolioUpdate(title="New Title", summary="New summary."),
+        user=user,
+    )
+
+    assert result.title == "New Title"
+    assert result.summary == "New summary."
+    assert result.content == {"projects": []}  # unchanged
+
+
+def test_edit_portfolio_partial_update():
+    """Service only updates provided fields, leaves others unchanged."""
+    now = datetime.now(timezone.utc)
+    portfolio = SimpleNamespace(
+        id=1, user_id=10, title="Original Title", summary="Original summary.",
+        content={"projects": []}, created_at=now, updated_at=now,
+    )
+
+    service = _make_edit_service(portfolio=portfolio)
+    user = SimpleNamespace(id=10, email="test@example.com")
+
+    result = service.update_portfolio(
+        portfolio_id=1,
+        data=PortfolioUpdate(title="Changed Title"),
+        user=user,
+    )
+
+    assert result.title == "Changed Title"
+    assert result.summary == "Original summary."  # unchanged
+
+
+def test_edit_portfolio_not_found():
+    """Service returns None when portfolio doesn't exist."""
+    service = _make_edit_service(portfolio=None)
+    user = SimpleNamespace(id=10, email="test@example.com")
+
+    result = service.update_portfolio(
+        portfolio_id=999,
+        data=PortfolioUpdate(title="New"),
+        user=user,
+    )
+
+    assert result is None
+
+
+def test_edit_portfolio_forbidden():
+    """Service returns 'forbidden' when user doesn't own the portfolio."""
+    now = datetime.now(timezone.utc)
+    portfolio = SimpleNamespace(
+        id=1, user_id=99, title="Title", summary="Summary.",
+        content={}, created_at=now, updated_at=now,
+    )
+
+    service = _make_edit_service(portfolio=portfolio)
+    user = SimpleNamespace(id=10, email="test@example.com")  # different user
+
+    result = service.update_portfolio(
+        portfolio_id=1,
+        data=PortfolioUpdate(title="Hacked"),
+        user=user,
+    )
+
+    assert result == "forbidden"
+
+
+# --- Edit endpoint tests ---
+
+
+def test_edit_portfolio_requires_auth():
+    """PUT /api/portfolio/1/edit returns 401 without auth token."""
+    response = client.put("/api/portfolio/1/edit", json={"title": "New"})
+
+    assert response.status_code == 401
+
+
+@patch("src.api.routes.portfolio.PortfolioService")
+def test_edit_portfolio_endpoint_success(mock_service_class):
+    """PUT /api/portfolio/1/edit returns 200 with updated data."""
+    from src.api.dependencies import get_current_user
+
+    now = datetime.now(timezone.utc)
+    fake_user = SimpleNamespace(id=10, email="test@example.com", is_active=True)
+
+    mock_service = MagicMock()
+    mock_service.update_portfolio.return_value = SimpleNamespace(
+        id=1,
+        user_id=10,
+        title="Updated Title",
+        summary="Updated summary.",
+        content={"projects": []},
+        created_at=now,
+        updated_at=now,
+    )
+    mock_service_class.return_value = mock_service
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    try:
+        response = client.put(
+            "/api/portfolio/1/edit",
+            json={"title": "Updated Title", "summary": "Updated summary."},
+        )
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == "Updated Title"
+    assert data["summary"] == "Updated summary."
+
+
+@patch("src.api.routes.portfolio.PortfolioService")
+def test_edit_portfolio_endpoint_not_found(mock_service_class):
+    """PUT /api/portfolio/999/edit returns 404 when portfolio doesn't exist."""
+    from src.api.dependencies import get_current_user
+
+    fake_user = SimpleNamespace(id=10, email="test@example.com", is_active=True)
+
+    mock_service = MagicMock()
+    mock_service.update_portfolio.return_value = None
+    mock_service_class.return_value = mock_service
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    try:
+        response = client.put("/api/portfolio/999/edit", json={"title": "New"})
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 404
+
+
+@patch("src.api.routes.portfolio.PortfolioService")
+def test_edit_portfolio_endpoint_forbidden(mock_service_class):
+    """PUT /api/portfolio/1/edit returns 403 when user doesn't own it."""
+    from src.api.dependencies import get_current_user
+
+    fake_user = SimpleNamespace(id=10, email="test@example.com", is_active=True)
+
+    mock_service = MagicMock()
+    mock_service.update_portfolio.return_value = "forbidden"
+    mock_service_class.return_value = mock_service
+
+    app.dependency_overrides[get_current_user] = lambda: fake_user
+    try:
+        response = client.put("/api/portfolio/1/edit", json={"title": "Hacked"})
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    assert response.status_code == 403
+    assert "not authorized" in response.json()["detail"].lower()


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds a PUT /api/portfolio/{portfolio_id}/edit endpoint that allows authenticated users to manually update their generated portfolio. The endpoint accepts partial updates through a PortfolioUpdate schema. Users can modify any combination of the title, summary, and content fields, and only the provided fields are updated while the rest remain unchanged. This is useful for refining AI-generated portfolio content after the initial generation, such as adjusting the summary wording, renaming the title, or removing or reordering projects within the content JSON. The endpoint enforces ownership validation, returning 403 if the authenticated user does not own the portfolio and 404 if the portfolio does not exist. This follows the same partial update pattern used by UserProfileUpdate elsewhere in the codebase, and no new dependencies are required.

<img width="711" height="586" alt="Screenshot 2026-02-22 at 16 25 03" src="https://github.com/user-attachments/assets/f1419c5b-24d1-44e8-bba7-18bc9a1f9261" />


**Closes:** #217

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Automated testing:

Run `docker compose exec backend python -m pytest tests/test_portfolio.py -q `

Manual Testing:

Prereq: You must be logged in (if not register from PUT/api/auth/register) and have already generated a portfolio from PUT /api/portfolio/generate.


1. Look for PUT /api/portfolio/{portfolio_id}/edit endpoint in the portfolio section. 
2. Click on to it and you will see something like in the following screenshot:
<img width="1512" height="805" alt="Screenshot 2026-02-22 at 16 10 19" src="https://github.com/user-attachments/assets/f7439760-7e73-4983-baf1-abd06369cd11" />

3. Go to PUT /api/portfolio/generate and copy the JSON's body from the title, summary, and content fields. 
<img width="1238" height="822" alt="Screenshot 2026-02-22 at 0 00 52" src="https://github.com/user-attachments/assets/ea11af38-2f0c-40fa-8101-3bb9267a720b" />


4. Go back to PUT /api/portfolio/{portfolio_id}/edit and then replace the fields from the generate's endpoint.
<img width="1493" height="720" alt="Screenshot 2026-02-22 at 16 16 02" src="https://github.com/user-attachments/assets/dfbeba80-b507-4068-bc7c-4f8a7b6e1961" />

5. Edit the field you want to make. For example, you could add/remove projects from content, change the title name and the description from summary.
<img width="1512" height="782" alt="Screenshot 2026-02-22 at 16 10 07" src="https://github.com/user-attachments/assets/3be57bc4-d055-4a1d-a883-fc69e6d8a36f" />

7. Execute 

<img width="1497" height="803" alt="Screenshot 2026-02-22 at 16 09 56" src="https://github.com/user-attachments/assets/43fb5954-6070-4b09-8b98-88c5355371c0" />



---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile